### PR TITLE
Enhance type detection and value conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     * [gnomish::application](#defined-type-gnomishapplication)
     * [gnomish::gnome::gconftool_2](#defined-type-gnomishgnomegconftool_2)
     * [gnomish::mate::mateconftool_2](#defined-type-gnomishmatemateconftool_2)
+5. [Changelog](#changelog)
 
 # Module description
 
@@ -134,7 +135,7 @@ gnomish::packages_remove:
 #### settings_xml (hash / optional)
 Specify desktop settings that will be passed to the `gnomish::gnome::gconftool_2` or `gnomish::mate::mateconftool_2` defined
 types, depending on the value of `$gnomish::desktop`. For a full description please read on at the
-[gconftool_2](#defined-type-gnomishgconftool_2) or [mateconftools_2](#defined-type-gnomishmateconftool_2) defined types.
+[gconftool_2](#defined-type-gnomishgnomegconftool_2) or [mateconftools_2](#defined-type-gnomishmatemateconftool_2) defined types.
 
 **Hint**: if you want to pass parameters from manifests you will need to set `$settings_xml_hiera_merge` to *false*.
 
@@ -223,7 +224,7 @@ If set to *true* hiera_merge will be used to collect and concatenate application
 ---
 #### settings_xml (hash / optional)
 Specify desktop settings that will be passed to the `gnomish::gnome::gconftool_2` defined type. For a full description please
-read on at the [mateconftools_2](#defined-type-gnomishmateconftool_2) defined type.
+read on at the [gconftools_2](#defined-type-gnomishgnomegconftool_2) defined type.
 
 
 **Hint**: if you want to pass parameters from manifests you will need to set `$settings_xml_hiera_merge` to *false*.
@@ -316,7 +317,7 @@ If set to *true* hiera_merge will be used to collect and concatenate application
 ---
 #### settings_xml (hash / optional)
 Specify desktop settings that will be passed to the `gnomish::mate::mateconftool_2` defined type. For a full description please
-read on at the [mateconftools_2](#defined-type-gnomishmateconftool_2) defined type.
+read on at the [mateconftools_2](#defined-type-gnomishmatemateconftool_2) defined type.
 
 
 **Hint**: if you want to pass parameters from manifests you will need to set `$settings_xml_hiera_merge` to *false*.
@@ -493,7 +494,8 @@ please specify the complete absolute path for it.
 ---
 #### key (string / optional)
 To specify which key you want to manage. If not explicitly set, it will use the resource title you have chosen while calling the
-defined type. See the [example](#example-for-gnome-only-settings) above for an example of both ways to pass the key name.
+defined type. See the [example](#example-for-hashed-settings_xml-resources-in-hiera) above for an example of both ways to pass the
+key name.
 
 - Default: ***$title***
 
@@ -505,3 +507,9 @@ to one of the other valid values of *bool*, *int*, *float* or *string*.
 - Default: ***'auto'***
 
 ---
+# Changelog
+
+* 1.0.3 Enhance spelling in docs
+* 1.0.2 Add tags in metadata
+* 1.0.1 Fix supported Puppet versions in metadata
+* 1.0.0 Initial release

--- a/manifests/gnome/gconftool_2.pp
+++ b/manifests/gnome/gconftool_2.pp
@@ -6,13 +6,34 @@ define gnomish::gnome::gconftool_2 (
 ) {
 
   # variable preparation
-  if $type == 'auto' {
-    $type_real = type3x($value) ? {
-      'boolean' => 'bool',
-      'integer' => 'int',
-      'float'   => 'float',
-      default   => 'string',
+  case type3x($value) {
+    'boolean':         {
+      $value_string = bool2str($value)
+      $value_type = 'bool'
     }
+    'integer': {
+      $value_string = sprintf('%g', $value)
+      $value_type = 'int'
+    }
+    'float': {
+      $value_string = sprintf('%g', $value)
+      $value_type = 'float'
+    }
+    'string': {
+      if $value =~ /^(true|false)$/ {
+        $value_string = $value
+        $value_type = 'bool'
+      }
+      else {
+        $value_string = $value
+        $value_type = 'string'
+      }
+    }
+    default: { fail('gnomish::gnome::gconftool_2::value is not a string.') }
+  }
+
+  if $type == 'auto' {
+    $type_real = $value_type
   }
   else {
     $type_real = $type
@@ -24,15 +45,13 @@ define gnomish::gnome::gconftool_2 (
     default     => $config,
   }
 
-  $value_string = "${value}" # lint:ignore:only_variable_string
-
   # variable validation
   validate_string($value_string)
   validate_absolute_path($config_real)
   if is_string($key) == false {
     fail('gnomish::gnome::gconftool_2::key is not a string.')
   }
-  validate_re($type_real, '^(bool|int|float|string)', "gnomish::gnome::gconftool_2::type must be one of <bool>, <int>, <float>, <string> or <auto> and is set to ${type_real}")
+  validate_re($type_real, '^(bool|int|float|string)$', "gnomish::gnome::gconftool_2::type must be one of <bool>, <int>, <float>, <string> or <auto> and is set to ${type_real}")
 
   # functionality
   exec { "gconftool-2 ${key}" :

--- a/manifests/mate/mateconftool_2.pp
+++ b/manifests/mate/mateconftool_2.pp
@@ -6,13 +6,34 @@ define gnomish::mate::mateconftool_2 (
 ) {
 
   # variable preparation
-  if $type == 'auto' {
-    $type_real = type3x($value) ? {
-      'boolean' => 'bool',
-      'integer' => 'int',
-      'float'   => 'float',
-      default   => 'string',
+  case type3x($value) {
+    'boolean':         {
+      $value_string = bool2str($value)
+      $value_type = 'bool'
     }
+    'integer': {
+      $value_string = sprintf('%g', $value)
+      $value_type = 'int'
+    }
+    'float': {
+      $value_string = sprintf('%g', $value)
+      $value_type = 'float'
+    }
+    'string': {
+      if $value =~ /^(true|false)$/ {
+        $value_string = $value
+        $value_type = 'bool'
+      }
+      else {
+        $value_string = $value
+        $value_type = 'string'
+      }
+    }
+    default: { fail('gnomish::gnome::gconftool_2::value is not a string.') }
+  }
+
+  if $type == 'auto' {
+    $type_real = $value_type
   }
   else {
     $type_real = $type
@@ -24,15 +45,13 @@ define gnomish::mate::mateconftool_2 (
     default     => $config,
   }
 
-  $value_string = "${value}" # lint:ignore:only_variable_string
-
   # variable validation
   validate_string($value_string)
   validate_absolute_path($config_real)
   if is_string($key) == false {
     fail('gnomish::mate::mateconftool_2::key is not a string.')
   }
-  validate_re($type_real, '^(bool|int|float|string)', "gnomish::mate::mateconftool_2::type must be one of <bool>, <int>, <float>, <string> or <auto> and is set to ${type_real}")
+  validate_re($type_real, '^(bool|int|float|string)$', "gnomish::mate::mateconftool_2::type must be one of <bool>, <int>, <float>, <string> or <auto> and is set to ${type_real}")
 
   # functionality
   exec { "mateconftool-2 ${key}" :

--- a/spec/defines/gnome__gconftool_2_spec.rb
+++ b/spec/defines/gnome__gconftool_2_spec.rb
@@ -75,15 +75,15 @@ describe 'gnomish::gnome::gconftool_2' do
   end
 
   auto_types = {
-    'bool'   => [true, false],
-    'int'    => [3],
-    'float'  => [2.42],
+    'bool'   => ['true', true, 'false', false],
+    'int'    => ['3', 3],
+    'float'  => ['2.42', 2.42],
     'string' => %w(string),
   }
 
   auto_types.each do |type, values|
     values.each do |value|
-      describe "with value set to valid <#{value}> (as #{value.class})" do
+      describe "with type on default <auto> and value set to valid <#{value}> (as #{value.class})" do
         let(:params) { { :value => value } }
 
         it do
@@ -124,13 +124,13 @@ describe 'gnomish::gnome::gconftool_2' do
       },
       'stringified' => {
         :name    => %w(value),
-        :valid   => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false],
-        :invalid => [],
+        :valid   => ['string', 3, 2.42, true, false],
+        :invalid => [%w(array), { 'ha' => 'sh' }],
         :message => 'is not a string',
       },
-      'regex desktop' => {
+      'regex type' => {
         :name    => %w(type),
-        :valid   => %w(auto bool boolean int integer float string),
+        :valid   => %w(auto bool int float string),
         :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, true, false],
         :message => 'gnomish::gnome::gconftool_2::type must be one of <bool>, <int>, <float>, <string> or <auto> and is set to',
       },

--- a/spec/defines/mate__mateconftool_2_spec.rb
+++ b/spec/defines/mate__mateconftool_2_spec.rb
@@ -75,15 +75,15 @@ describe 'gnomish::mate::mateconftool_2' do
   end
 
   auto_types = {
-    'bool'   => [true, false],
-    'int'    => [3],
-    'float'  => [2.42],
+    'bool'   => ['true', true, 'false', false],
+    'int'    => ['3', 3],
+    'float'  => ['2.42', 2.42],
     'string' => %w(string),
   }
 
   auto_types.each do |type, values|
     values.each do |value|
-      describe "with value set to valid <#{value}> (as #{value.class})" do
+      describe "with type on default <auto> and value set to valid <#{value}> (as #{value.class})" do
         let(:params) { { :value => value } }
 
         it do
@@ -124,13 +124,13 @@ describe 'gnomish::mate::mateconftool_2' do
       },
       'stringified' => {
         :name    => %w(value),
-        :valid   => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false],
-        :invalid => [],
+        :valid   => ['string', 3, 2.42, true, false],
+        :invalid => [%w(array), { 'ha' => 'sh' }],
         :message => 'is not a string',
       },
-      'regex desktop' => {
+      'regex type' => {
         :name    => %w(type),
-        :valid   => %w(auto bool boolean int integer float string),
+        :valid   => %w(auto bool int float string),
         :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, true, false],
         :message => 'gnomish::mate::mateconftool_2::type must be one of <bool>, <int>, <float>, <string> or <auto> and is set to',
       },


### PR DESCRIPTION
Stringified booleans, integers, and floats in $value are now detected precisely if type is not manually set.
Stringified booleans, integers, and floats in $value are now correctly converted to strings.
