### PR TITLE
Allow empty values to {g,mate}conftool

### DIFF
--- a/manifests/gnome/gconftool_2.pp
+++ b/manifests/gnome/gconftool_2.pp
@@ -36,7 +36,7 @@
 #   this by setting type to one of the other valid values of bool, int, float or string.
 #
 define gnomish::gnome::gconftool_2 (
-  Variant[Boolean, Float, Integer, String[1]]                  $value,
+  Variant[Boolean, Float, Integer, String]                     $value,
   Variant[Stdlib::Absolutepath, Enum['defaults', 'mandatory']] $config = 'defaults',
   String[1]                                                    $key    = $title,
   Enum['auto', 'bool', 'int', 'float', 'string']               $type   = 'auto',

--- a/manifests/mate/mateconftool_2.pp
+++ b/manifests/mate/mateconftool_2.pp
@@ -38,7 +38,7 @@
 #   this by setting type to one of the other valid values of bool, int, float or string.
 #
 define gnomish::mate::mateconftool_2 (
-  Variant[Boolean, Float, Integer, String[1]]                  $value,
+  Variant[Boolean, Float, Integer, String]                     $value,
   Variant[Stdlib::Absolutepath, Enum['defaults', 'mandatory']] $config = 'defaults',
   String[1]                                                    $key    = $title,
   Enum['auto', 'bool', 'int', 'float', 'string']               $type   = 'auto',

--- a/spec/defines/gnome__gconftool_2_spec.rb
+++ b/spec/defines/gnome__gconftool_2_spec.rb
@@ -137,9 +137,9 @@ describe 'gnomish::gnome::gconftool_2' do
           invalid: [['array'], { 'ha' => 'sh' }, 3, 2.42, false],
           message: 'expects a String',
         },
-        'Variant[Boolean, Float, Integer, String[1]]' => {
+        'Variant[Boolean, Float, Integer, String]' => {
           name:    ['value'],
-          valid:   [true, false, 2.42, 3, false, 'string'],
+          valid:   [true, false, 2.42, 3, false, 'string', ''],
           invalid: [['array'], { 'ha' => 'sh' }],
           message: 'type Boolean, Float, Integer, or String,',
         },

--- a/spec/defines/mate__mateconftool_2_spec.rb
+++ b/spec/defines/mate__mateconftool_2_spec.rb
@@ -138,9 +138,9 @@ describe 'gnomish::mate::mateconftool_2' do
           invalid: [['array'], { 'ha' => 'sh' }, 3, 2.42, false],
           message: 'expects a String',
         },
-        'Variant[Boolean, Float, Integer, String[1]]' => {
+        'Variant[Boolean, Float, Integer, String]' => {
           name:    ['value'],
-          valid:   [true, false, 2.42, 3, false, 'string'],
+          valid:   [true, false, 2.42, 3, false, 'string', ''],
           invalid: [['array'], { 'ha' => 'sh' }],
           message: 'type Boolean, Float, Integer, or String,',
         },


### PR DESCRIPTION
Sometimes value should be set to an empty string. Allow empty strings.